### PR TITLE
added setPackages function, analog to setExport

### DIFF
--- a/R/doRedis.R
+++ b/R/doRedis.R
@@ -43,6 +43,11 @@ setExport <- function(names=c())
   assign('export', names, envir=.doRedisGlobals)
 }
 
+setPackages <- function(packages=c())
+{
+  assign('packages', packages, envir=.doRedisGlobals)
+}
+
 # The number of workers should be considered an estimate that may change.
 .info <- function(data, item) {
   switch(item,
@@ -134,9 +139,12 @@ setExport <- function(names=c())
              pos=exportenv, inherits=FALSE)
     }
   }
+	# export packages
+	packages <- unique(c(obj$packages, .doRedisGlobals$packages))
+	
 # Create a job environment for the workers to use
   redisSet(queueEnv, list(expr=expr, 
-                          exportenv=exportenv, packages=obj$packages))
+                          exportenv=exportenv, packages=packages))
   results <- NULL
   njobs <- length(argsList)
 # foreach lets one pass options to a backend with the .options.<label>


### PR DESCRIPTION
similarly to the setExport method I need an option to force workers to load certain packages in situations where I can't set the .packages variable of the foreach function (e.g. because foreach is called by a plyr function). 
