### PR TITLE
Worker multiple queues fix

### DIFF
--- a/R/doRedis.R
+++ b/R/doRedis.R
@@ -344,10 +344,14 @@ setProgress <- function(value=FALSE)
 # ID associates the work with a job environment <queue>.env.<ID>. If
 # the workers current job environment does not match job ID, they retrieve
 # the new job environment data from queueEnv and run workerInit.
+
   ID <- basename(tempfile(""))
 # The backslash escape charater present in Windows paths causes problems.
   ID <- gsub("\\\\", "", ID)
-  ID <- paste(ID, Sys.info()["user"], Sys.info()["nodename"], Sys.time(), sep="_")
+  
+  # tempfile can produce the same name if used in multiple threads; adding PID avoids this problem
+  ID <- paste(Sys.getpid(), ID, sep = "")
+  ID <- paste( ID, Sys.info()["user"], Sys.info()["nodename"], Sys.time(), sep="_")
   ID <- gsub(" ", "-", ID)
   queue <- data$queue
   queueEnv <- paste(queue,"env", ID, sep=".")

--- a/R/redisWorker.R
+++ b/R/redisWorker.R
@@ -108,8 +108,11 @@ startLocalWorkers <- function(n, queue, host="localhost", port=6379,
   if(is.null(conargs$timeout)) conargs$timeout <- 3600
   conargs <- paste(paste(names(conargs), conargs, sep="="), collapse=",")
   
-  cmd <- paste("require(doRedis);redisWorker(queue='",
-      queue, "', host='", host,"', port=", port,", iter=", iter,", linger=",
+  # ensure that we pass multiple queues, if applicable, to each worker
+  queue <- sprintf("c(%s)", paste("'", queue, "'", collapse=", ", sep=""))
+
+  cmd <- paste("require(doRedis);redisWorker(queue=",
+      queue, ", host='", host,"', port=", port,", iter=", iter,", linger=",
       linger, ", log=", deparse(l), sep="")
   if(nchar(conargs) > 0) cm <- sprintf("%s, %s", cmd, conargs)
   if(!missing(password)) cmd <- sprintf("%s, password='%s'", cmd, password)

--- a/R/redisWorker.R
+++ b/R/redisWorker.R
@@ -187,8 +187,11 @@ redisWorker <- function(queue, host="localhost", port=6379,
     log <- file(log, open="w+")
   sink(type="message", file=log)
   assign(".jobID", "0", envir=.doRedisGlobals)
+  
   queueLive <- paste(queue, "live", sep=".")
-  if(!redisExists(queueLive)) redisSet(queueLive, "")
+  for(j in queueLive)
+    if(!redisExists(j)) redisSet(j, "")
+  
   queueCount <- paste(queue,"count",sep=".")
   for (j in queueCount)
     tryCatch(redisIncr(j),error=function(e) invisible())


### PR DESCRIPTION
Addresses an issue when multiple queues are entered for startLocalWorker. This accounts for the multiple queues in the string used for the system command for redisWorker. 