### PR TITLE
Fix uncerealize()

### DIFF
--- a/R/redux.R
+++ b/R/redux.R
@@ -34,7 +34,7 @@ redisGetContext <- function()
 
 uncerealize <- function(x)
 {
-  if(!is.null(x) && is.raw(x)) unserialize(x) else NULL
+  if(!is.null(x) && is.raw(x)) unserialize(x) else x
 }
 
 redisExists <- function(key)


### PR DESCRIPTION
Regarding issue #57, `redisGet()` cannot return the correct queue count because `uncerealize()` returns `NULL` for strings such as `"3"`.